### PR TITLE
New recipient subhash on MESSAGE requests:

### DIFF
--- a/specification.md
+++ b/specification.md
@@ -494,7 +494,7 @@ Request Parameters:
       "username": <username of message author on requester>,
       "recipients": [
         {
-          "username": <recipient's username on responder> },
+          "username": <recipient's username> },
           "public_key": <public key of recipient's server>,
         }
         [[ ... ]]


### PR DESCRIPTION
 include public_key of recipient's tree.

See also:

https://github.com/Libertree/libertree-model-rb/pull/5
https://github.com/Libertree/libertree-client-rb/pull/2
https://github.com/Libertree/libertree-backend-rb/pull/5
https://github.com/Libertree/libertree-frontend-ramaze/pull/31
